### PR TITLE
Misc 2: CloudFormation (Terraform-anchored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@
   - [How MSK and Flink Fit Together](#how-msk-and-flink-fit-together)
   - [Kafka vs SNS vs Redis pub/sub](#kafka-vs-sns-vs-redis-pubsub)
   - [Amazon EventBridge](#amazon-eventbridge)
+  - [Amazon SES (Simple Email Service)](#amazon-ses-simple-email-service)
 - [Amazon Redshift](#amazon-redshift)
   - [When People Reach for Redshift](#when-people-reach-for-redshift)
   - [OLTP vs OLAP](#oltp-vs-olap)
@@ -14159,6 +14160,63 @@ Exam phrasing: *"schedule a one-time invocation of a Lambda 3 hours from now"* �
 - *"the service formerly known as CloudWatch Events"* → **EventBridge**
 
 **The 80/20:** *EventBridge = content-routed event bus = CloudWatch Events rebrand + custom + partner buses + Archive/Replay + Pipes + Scheduler + Schema Registry. Pick EventBridge over SNS when you need content-based filtering, SaaS sources, or replay. Pick SNS when you need simple, fastest fan-out. The exam tests the rebrand trap ("CloudWatch Events" → EventBridge), the SaaS-source angle, Archive+Replay uniqueness, and Pipes for "no Lambda glue".*
+
+### Amazon SES (Simple Email Service)
+
+AWS's **programmatic email-sending API**. Anchor: *SendGrid / Mailgun / Postmark / Mailchimp Transactional — except AWS-native and dirt cheap* (~$0.10 per 1,000 emails sent from EC2). It's a sending service, not an inbox product.
+
+#### Who actually uses it
+
+| Caller | Why |
+| ------ | --- |
+| **Your app on EC2 / ECS / EKS / Lambda** | The 90% case — send transactional email (signup confirmation, password reset, order confirmation, receipt, alert) via SES API/SMTP |
+| **Amazon Cognito** | When you customise sender for User Pool emails (verification, password reset, MFA), Cognito uses **SES under the hood** — must verify the sender identity in SES first |
+| **AWS Pinpoint** | Pinpoint (multi-channel customer engagement: email + SMS + push) uses **SES under the hood** for its email channel |
+| **CI/CD or batch jobs** | Nightly job sending reports, alerts, monthly billing — Lambda + SES |
+| **Receive-side automation** | SES can also **receive** email (MX → SES → S3 / Lambda / SNS). Use cases: bounce-processing inbox, support@ triage, ingest replies into a workflow |
+
+#### Typical use cases on the exam
+
+1. **Transactional email** — account signup, password reset, order confirmation, shipping notification, receipts, security alerts. *The default SES answer.*
+2. **Bulk marketing email** — newsletters, promo campaigns. Supported but harder (reputation, suppression list management).
+3. **Application-generated notifications** — Lambda triggers, CloudWatch alarms feeding a Lambda that formats and SES-sends a rich email.
+4. **Inbound email processing** — SES receives via MX → drops into S3 → Lambda processes (e.g., parse customer reply, file as ticket).
+
+#### What SES is NOT
+
+| Confused with | Actually is |
+| ------------- | ----------- |
+| **SNS** | Pub/sub fanout. Can send email to subscribers but it's plain-text and limited — not a transactional email service. *"Send a rich receipt to a customer" → SES, not SNS* |
+| **SQS** | A queue. Often *paired* with SES (queue outgoing emails, Lambda consumes and calls SES) but doesn't send email itself |
+| **Amazon WorkMail** | Hosted inboxes for employees (like Gmail / Office 365). SES is the sending API, not a mailbox product |
+| **Amazon Pinpoint** | Multi-channel customer engagement (email + SMS + push + analytics + targeting). Uses SES *under the hood* for email. Use Pinpoint if you need campaigns + targeting; use SES if you just need to send |
+| **AWS Chatbot** | Sends Slack / Teams / Chime messages from CloudWatch / SNS. Nothing to do with email |
+
+#### Exam-relevant SES gotchas
+
+| Gotcha | Detail |
+| ------ | ------ |
+| **Sandbox mode by default** | New SES accounts can only send to **verified** addresses, max 200/day, 1/sec. Must **request production access** to lift this — heavily tested phrasing |
+| **Verified identities required** | Must verify the **sender domain or email** before SES will send on its behalf. DKIM/SPF/DMARC for deliverability |
+| **Bounce / complaint handling** | If you ignore bounces and complaints, SES will throttle or suspend you. Configure SNS notifications on bounces → process them |
+| **Configuration Sets** | Group settings for event publishing (bounces → SNS / Kinesis / CloudWatch), suppression, IP pools |
+| **Suppression list** | Auto-suppresses addresses that bounced/complained — prevents you damaging reputation |
+| **Dedicated IPs** | High-volume senders who need to warm and own their IP reputation (vs. SES shared pool) |
+
+#### Exam triggers
+
+| Question phrasing | Answer |
+| ----------------- | ------ |
+| *"Send password reset / order confirmation / signup email at scale and cheaply from a Lambda"* | **Amazon SES** |
+| *"Cognito needs to send branded verification emails from your domain"* | **Cognito + SES** (verify domain in SES, configure Cognito to use it) |
+| *"Receive email at support@ and trigger a workflow"* | **SES inbound** → S3 / Lambda / SNS |
+| *"Multi-channel campaign with email + SMS + push to segmented users"* | **Amazon Pinpoint** (uses SES under the hood) |
+| *"Send notification to ops team when CloudWatch alarm fires"* | **SNS email subscription** (not SES — fanout, simple) |
+| *"Why is my new SES account only sending to my own email and capped at 200/day?"* | **Sandbox mode** — request production access |
+| *"My SES sending rate dropped — why?"* | High bounce/complaint rate triggered throttling — process bounce SNS notifications, clean list |
+| *"Hosted email inboxes for our 500 employees"* | **Amazon WorkMail** (NOT SES) |
+
+> *SES = the cheap, programmatic email-sending API for anything running on AWS that needs to send transactional or marketing email. Sandbox-by-default (verify identities and request production access), domain verification + DKIM for deliverability, bounce/complaint handling mandatory. Pinpoint and Cognito both use it under the hood. NOT SNS (pub/sub), NOT WorkMail (inboxes), NOT Pinpoint (multi-channel campaigns).*
 
 ## Amazon Redshift
 

--- a/README.md
+++ b/README.md
@@ -14218,6 +14218,18 @@ AWS's **programmatic email-sending API**. Anchor: *SendGrid / Mailgun / Postmark
 
 > *SES = the cheap, programmatic email-sending API for anything running on AWS that needs to send transactional or marketing email. Sandbox-by-default (verify identities and request production access), domain verification + DKIM for deliverability, bounce/complaint handling mandatory. Pinpoint and Cognito both use it under the hood. NOT SNS (pub/sub), NOT WorkMail (inboxes), NOT Pinpoint (multi-channel campaigns).*
 
+#### Pinpoint — the one-line distinction
+
+**Amazon Pinpoint** is the customer engagement / marketing layer that sits *on top of* SES (and the SMS/push infra). It adds **segments, campaigns, journeys, A/B testing, and analytics** — things SES doesn't do. Low-frequency on SAA-C03, but the distinction matters:
+
+| Phrasing | Pick |
+| -------- | ---- |
+| *"Marketing campaign to a user segment, multi-channel, A/B test, multi-step journey"* | **Pinpoint** |
+| *"Send a transactional / one-off email from app code"* | **SES** |
+| *"System notification to ops team / pub-sub fanout"* | **SNS** |
+
+Pinpoint uses SES under the hood for email — it's not a competitor, it's the orchestrator layer above.
+
 ## Amazon Redshift
 
 AWS's **data warehouse** — designed for running analytics queries across massive datasets (petabytes). Not a transactional database like RDS — it's for **OLAP** (Online Analytical Processing), not OLTP.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@
   - [Secrets Manager vs Parameter Store — the Comparison](#secrets-manager-vs-parameter-store--the-comparison)
   - [Common Anti-patterns (exam wrong answers)](#common-anti-patterns-exam-wrong-answers-19)
   - [Exam Triggers](#exam-triggers-19)
+- [AWS Systems Manager (Session Manager, Run Command, Patch Manager)](#aws-systems-manager-session-manager-run-command-patch-manager)
+  - [Session Manager — how it actually works at the network layer](#session-manager--how-it-actually-works-at-the-network-layer)
+  - [The three SSM endpoints (all port 443)](#the-three-ssm-endpoints-all-port-443)
+  - [Numbered flow — what happens when you start a session](#numbered-flow--what-happens-when-you-start-a-session)
+  - [Security group requirements](#security-group-requirements)
+  - [Private subnet — VPC Interface Endpoints required](#private-subnet--vpc-interface-endpoints-required)
+  - [Port forwarding via SSM](#port-forwarding-via-ssm)
+  - [Other SSM capabilities the exam touches](#other-ssm-capabilities-the-exam-touches)
+  - [What Session Manager is NOT](#what-session-manager-is-not)
+  - [Exam Triggers for SSM](#exam-triggers-for-ssm)
 - [Amazon GuardDuty](#amazon-guardduty)
   - [What GuardDuty is NOT](#what-guardduty-is-not)
   - [Core Concepts](#core-concepts-8)
@@ -6674,6 +6684,151 @@ Does the value need automatic rotation managed by AWS?
 - *"App needs both config and rotating DB password"* → **Hybrid: Parameter Store for config + reference to Secrets Manager**
 
 **The 80/20:** *Parameter Store = part of SSM, **free up to 10,000 params** on Standard tier, hierarchical paths (`/app/env/key`), three types (String / StringList / SecureString-KMS). Use for **config + non-rotating secrets**. Pair with Secrets Manager via `/aws/reference/secretsmanager/...` reference syntax so apps read everything from one API but rotating secrets are managed by Secrets Manager. **Advanced tier** ($0.05/param/month) only when you need >10,000 params, >4 KB values, expiration policies, or change notifications. Public parameters give you AWS-published values like latest AMIs.*
+
+## AWS Systems Manager (Session Manager, Run Command, Patch Manager)
+
+**Anchored against Ansible / Salt / Tanium — but AWS-native and agentless from a network standpoint.** Systems Manager is the umbrella for fleet operations: shell access (Session Manager), running scripts (Run Command), OS patching (Patch Manager), inventory, automation, change calendars. Parameter Store (covered above) is also technically part of SSM but is usually treated separately on the exam.
+
+The headline exam topic is **Session Manager**: shell into EC2 without opening any inbound port.
+
+### Session Manager — how it actually works at the network layer
+
+```
+EC2 instance                                AWS SSM endpoints
+┌────────────────┐                         ┌──────────────────────┐
+│ SSM Agent      │ ─────► TCP 443 ───────► │ ssm.<region>.        │
+│ (long-poll /   │ ─────► HTTPS ─────────► │ amazonaws.com        │
+│  WebSocket)    │ ─────► outbound only ─► │ ssmmessages.<region> │
+│                │                         │ ec2messages.<region> │
+└────────────────┘                         └──────────────────────┘
+       ▲
+       │ no inbound — SG can be `deny all in`
+```
+
+The SSM agent (pre-installed on Amazon Linux 2/2023, Ubuntu, Windows AMIs) opens a **persistent outbound HTTPS connection** to three regional SSM endpoints. When you start a session from your laptop, the session traffic flows **down through that pre-existing outbound tunnel** to the agent. Your laptop never connects directly to the instance.
+
+**It is all 443. No other ports involved.** No SSH (22), no RDP (3389), no custom agent port.
+
+### The three SSM endpoints (all port 443)
+
+| Endpoint | Purpose |
+| -------- | ------- |
+| `ssm.<region>.amazonaws.com` | Control plane API (state, inventory, run commands) |
+| `ssmmessages.<region>.amazonaws.com` | The **Session Manager** websocket channel — actual shell traffic flows here |
+| `ec2messages.<region>.amazonaws.com` | Legacy bidirectional messaging — still required by older agent versions for Run Command etc. |
+
+### Numbered flow — what happens when you start a session
+
+```
+1. SSM Agent on EC2 boots → opens outbound HTTPS to ssmmessages.<region> (port 443)
+   → connection stays open (long-poll / WebSocket)
+        ↓
+2. You run: aws ssm start-session --target i-0abc123
+   → CLI hits the SSM control plane API (443)
+   → IAM check: "can this user start a session on this instance?"
+        ↓
+3. SSM service tells the waiting agent (via the open WebSocket): "open a shell, route stdin/stdout to me"
+        ↓
+4. Your CLI opens its own outbound 443 connection to ssmmessages
+   → SSM bridges the two WebSocket connections (your CLI ↔ SSM ↔ agent ↔ shell)
+        ↓
+5. Every keystroke you type:
+   → CLI → 443 → SSM → 443 → agent → /bin/bash → stdout
+   → return path same in reverse
+        ↓
+6. Session log (if enabled) → streams to CloudWatch Logs or S3
+```
+
+**At no point does any inbound port open on the instance.** Security group inbound can be empty.
+
+### Security group requirements
+
+| Direction | Required |
+| --------- | -------- |
+| **Inbound** | **Nothing** — no port 22, no port 3389, nothing |
+| **Outbound** | **TCP 443 to the SSM endpoints** (or to `0.0.0.0/0` if egress is open) |
+
+That's the magic — you can run an EC2 with `inbound: deny all` and still get a shell. The IAM role attached to the instance must allow the `AmazonSSMManagedInstanceCore` policy (or equivalent), and the user starting the session needs `ssm:StartSession` permission.
+
+### Private subnet — VPC Interface Endpoints required
+
+If the instance is in a private subnet without internet access (no NAT gateway), you must create **VPC interface endpoints** for the three SSM endpoints so the agent can reach them privately:
+
+| VPC Endpoint | What for |
+| ------------ | -------- |
+| `com.amazonaws.<region>.ssm` | Control plane |
+| `com.amazonaws.<region>.ssmmessages` | Session Manager traffic |
+| `com.amazonaws.<region>.ec2messages` | Run Command etc. |
+
+Plus `s3` and `logs` VPC endpoints if you're logging sessions to S3 / CloudWatch.
+
+**This is heavily exam-tested**: *"SSM Session Manager not working from private subnet — what's needed?"* → **VPC interface endpoints for `ssm`, `ssmmessages`, `ec2messages`**.
+
+### Port forwarding via SSM
+
+You can tunnel arbitrary TCP ports **through** the 443 SSM channel to reach things like RDS, RDP, or internal services — without ever opening those ports to the world:
+
+```bash
+# Tunnel local port 9999 -> instance's port 3306 (MySQL) through SSM
+aws ssm start-session \
+  --target i-0abc123 \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["3306"],"localPortNumber":["9999"]}'
+
+# Then connect MySQL locally:
+mysql -h localhost -P 9999 -u admin -p
+```
+
+Or to reach a remote host **from** the EC2 instance (e.g., reach RDS through an EC2 jump):
+
+```bash
+aws ssm start-session \
+  --target i-0abc123 \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["rds.private.dns"],"portNumber":["3306"],"localPortNumber":["9999"]}'
+```
+
+The tunnel itself is still **443 outbound** from instance to AWS.
+
+### Other SSM capabilities the exam touches
+
+| Capability | What it does |
+| ---------- | ------------ |
+| **Run Command** | Execute scripts/commands across a fleet of instances. Uses the same agent + 443 channel. IAM-controlled, results captured |
+| **Patch Manager** | Schedule OS patching across fleets. Uses **Patch Baselines** (which patches are approved) and **Maintenance Windows** (when to apply). Heavy compliance reporting |
+| **State Manager** | Continuously enforce desired configuration (like Ansible playbooks running on a schedule) |
+| **Inventory** | Collect OS/package/installed-app inventory across fleets — feeds into compliance / Config |
+| **Automation (SSM Documents)** | Pre-built or custom runbooks for common ops tasks (patch + reboot, snapshot then resize, EBS encrypt-in-place). The "AWS-…" documents are AWS-managed |
+| **Hybrid activations** | Register **on-premises servers** as SSM-managed instances so all of the above works on-prem too. Uses a one-time activation code + 443 outbound |
+| **Change Calendar / Change Manager** | Block automation/patching during freeze windows. Tested in governance scenarios |
+
+### What Session Manager is NOT
+
+| Confused with | Actually is |
+| ------------- | ----------- |
+| **SSH bastion / jump host** | Bastion = a public-facing EC2 with inbound 22, keypair management, hardened access. SSM = no host, no inbound port, no keypair, IAM-based |
+| **EC2 Instance Connect (EIC)** | EIC pushes a temporary SSH public key via API, then **still uses SSH on port 22** (just via Instance Connect Endpoint or direct). SSM uses no SSH at all |
+| **VPN / Client VPN** | VPN routes IP traffic across networks. SSM is application-layer session brokering — single instance, single shell |
+| **Direct Connect / Site-to-Site VPN** | Network connectivity products. SSM is admin access |
+| **AWS Cloud9** | Cloud9 is a browser-based IDE that runs on EC2 (or your own host); not a shell-broker. Separate product |
+
+### Exam Triggers for SSM
+
+| Question phrasing | Answer |
+| ----------------- | ------ |
+| *"Shell into EC2 without opening port 22 / without a bastion"* | **SSM Session Manager** |
+| *"No inbound security group rules but admins need shell access"* | **SSM Session Manager** |
+| *"EC2 in private subnet, no internet, SSM not working"* | Create **VPC interface endpoints** for `ssm`, `ssmmessages`, `ec2messages` |
+| *"Audit log of every command run during admin sessions"* | **SSM Session Manager** with logging to **CloudWatch Logs / S3** |
+| *"Access RDS in private subnet from laptop without VPN or bastion"* | **SSM Port Forwarding to Remote Host** (tunnel through an EC2 to reach RDS) |
+| *"No port 22 but admins want shell, no keypair management, IAM-based access"* | **SSM Session Manager** |
+| *"Patch 500 EC2 instances on a schedule with compliance reporting"* | **SSM Patch Manager** with Patch Baselines + Maintenance Windows |
+| *"Run a script across all instances tagged `env=prod`"* | **SSM Run Command** |
+| *"Manage on-premises servers with the same tooling as EC2"* | **SSM Hybrid Activations** |
+| *"Continuously enforce that all instances have CloudWatch agent installed"* | **SSM State Manager** |
+| *"Prevent automation from running during the holiday freeze window"* | **SSM Change Calendar** |
+
+> *SSM = umbrella for fleet ops over a single outbound HTTPS 443 channel from the agent. Session Manager is the headline feature — shell access with **no inbound ports, no SSH keys, IAM-based**. In private subnets, **VPC interface endpoints for `ssm`, `ssmmessages`, `ec2messages`** are mandatory. Port forwarding tunnels other TCP ports (3306, 3389) over the same 443. Run Command runs scripts at fleet scale, Patch Manager handles OS patching with Baselines + Maintenance Windows, State Manager continuously enforces config, Hybrid Activations extend all of this to on-prem servers.*
 
 ## Amazon GuardDuty
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,14 @@
   - [Exam Triggers](#exam-triggers-21)
   - [Mental Model](#mental-model-2)
 - [Elastic Beanstalk](#elastic-beanstalk)
+- [AWS CloudFormation](#aws-cloudformation)
+  - [Concept mapping (CF → Terraform)](#concept-mapping-cf--terraform)
+  - [What CloudFormation does that Terraform doesn't (or does better)](#what-cloudformation-does-that-terraform-doesnt-or-does-better)
+  - [What Terraform does that CloudFormation doesn't (or does better)](#what-terraform-does-that-cloudformation-doesnt-or-does-better)
+  - [Exam-relevant CloudFormation specifics](#exam-relevant-cloudformation-specifics)
+  - [CloudFormation vs Terraform — decision matrix](#cloudformation-vs-terraform--decision-matrix)
+  - [Exam triggers](#exam-triggers-22)
+  - [Mental model](#mental-model-5)
 - [Solution Architecture Examples](#solution-architecture-examples)
   - [Classic Web App](#classic-web-app)
   - [Stateful Web App → Stateless Evolution](#stateful-web-app--stateless-evolution)
@@ -11445,6 +11453,186 @@ Under the hood it creates real AWS resources (EC2, ALB, ASG, etc.) that you can 
 - **Latest runtimes** — platform versions can lag behind the latest Node.js, Python, etc.
 
 **Exam shortcut:** "developer", "simple deployment", "minimal infrastructure" → **Beanstalk**. "Microservices", "complex architecture", "fine-grained control" → **ECS/Fargate** or plain EC2.
+
+## AWS CloudFormation
+
+**Anchored against Terraform.** CloudFormation is AWS's native IaC service. If you know Terraform, you already know 80% of CloudFormation — it's the same idea (declarative templates → reconciled state) restricted to AWS resources. This section focuses on **what's different from Terraform** rather than re-teaching IaC concepts.
+
+### Concept mapping (CF → Terraform)
+
+| CloudFormation | Terraform equivalent |
+| -------------- | --------------------- |
+| **Template** (YAML or JSON) | `.tf` files (HCL) |
+| **Stack** | A workspace + its state file |
+| **Resources** | `resource` blocks |
+| **Parameters** | `variable` blocks |
+| **Outputs** | `output` blocks |
+| **Mappings** | `locals` lookup maps |
+| **Conditions** | `count = condition ? 1 : 0` / `for_each` patterns |
+| **Intrinsic Functions** (`!Ref`, `!GetAtt`, `!Sub`, `!Join`) | Native HCL expressions (richer) |
+| **Pseudo-parameters** (`AWS::Region`, `AWS::AccountId`) | `data.aws_region.current.name`, `data.aws_caller_identity.current.account_id` |
+| **Change Set** | `terraform plan` |
+| **Stack Update** | `terraform apply` |
+| **Drift Detection** | `terraform plan` (shows drift) — but CF is native per-resource |
+| **DependsOn** | `depends_on` |
+| **DeletionPolicy / UpdateReplacePolicy** | `lifecycle { prevent_destroy = true }` |
+| **Nested Stacks** | Modules (looser equivalent) |
+| **Cross-Stack References** (`Export` + `!ImportValue`) | Module outputs / remote state |
+| **StackSets** | Custom orchestration (workspaces, scripts) — no direct equivalent |
+| **CloudFormation Registry** (custom resource types) | Custom providers |
+| **Macros** | No real Terraform equivalent (template pre-processors) |
+| **Helper scripts** (cfn-init / cfn-signal / cfn-hup) | No equivalent — provisioners come close but are discouraged |
+| **SAM** (`Transform: AWS::Serverless-2016-10-31`) | Just the AWS provider's serverless resources |
+| **CDK** (TypeScript/Python → CF) | CDKTF (CDK for Terraform) — much less common |
+
+### What CloudFormation does that Terraform doesn't (or does better)
+
+| Feature | Why it matters |
+| ------- | -------------- |
+| **Automatic rollback on failure** | If a stack update fails partway, CF reverses everything. Terraform leaves you with a half-applied mess + a tainted state file |
+| **State managed by AWS** | No S3 backend + DynamoDB lock setup. The stack IS the state |
+| **Native drift detection per resource** | CF can flag *which specific resource attributes* drifted. Terraform shows you the whole plan diff |
+| **StackSets** | Deploy the same template to **many accounts + regions** in one go. Terraform requires custom orchestration (Terragrunt, CI scripts) |
+| **DeletionPolicy: Retain / Snapshot** | Per-resource policy that survives stack deletion. Terraform's `prevent_destroy` blocks deletion instead of preserving the resource |
+| **Helper scripts for EC2 bootstrap** (`cfn-init`, `cfn-signal`, `cfn-hup`) | EC2 user data that reports back to the stack for true wait-for-readiness. Terraform user data is fire-and-forget |
+| **CloudFormation Hooks (proactive validation)** | Block resource creation in CF / Terraform / CDK BEFORE deployment if it violates policy. Like SCPs but at deployment time |
+| **Native integration with Service Catalog + Control Tower + AWS Backup, etc.** | These AWS services *speak* CloudFormation — no glue code |
+
+### What Terraform does that CloudFormation doesn't (or does better)
+
+| Feature | Why it matters |
+| ------- | -------------- |
+| **Multi-cloud** | CF is AWS-only. Terraform speaks AWS + Azure + GCP + Cloudflare + GitHub + … |
+| **Rich expression language (HCL)** | Loops, conditionals, complex transformations. CF's intrinsic functions are awkward by comparison |
+| **Module ecosystem** | Terraform Registry has thousands of community modules. CF Registry is mostly AWS-published |
+| **Better tooling for diffs** | `terraform plan` is generally more readable than CF Change Sets |
+| **Workspace flexibility** | Multiple environments via workspaces / Terragrunt; CF stacks are 1:1 with environments |
+| **Faster iteration** | Plan + apply cycle is faster than CF stack updates (CF can take minutes for trivial changes) |
+
+### Exam-relevant CloudFormation specifics
+
+#### Stack lifecycle and rollback
+
+```
+CREATE_IN_PROGRESS → CREATE_COMPLETE        (happy path)
+                  ↘ CREATE_FAILED → ROLLBACK_IN_PROGRESS → ROLLBACK_COMPLETE
+                                                          ↘ ROLLBACK_FAILED (manual cleanup)
+
+UPDATE_IN_PROGRESS → UPDATE_COMPLETE
+                   ↘ UPDATE_FAILED → UPDATE_ROLLBACK_IN_PROGRESS → UPDATE_ROLLBACK_COMPLETE
+```
+
+**Automatic rollback** is the headline behaviour CF gets and Terraform doesn't. Exam framing: *"if any resource fails during stack creation, what happens?"* → CF rolls back **all** changes by default (can be disabled, rarely a good idea).
+
+#### Change Sets — preview before apply
+
+```bash
+aws cloudformation create-change-set ...    # generates the diff
+aws cloudformation describe-change-set ...  # shows what would change
+aws cloudformation execute-change-set ...   # applies it
+```
+
+Equivalent of `terraform plan → terraform apply`. Critical for production — always review before executing.
+
+#### StackSets — multi-account multi-region (the headline CF feature)
+
+The thing CF does that Terraform really can't match natively:
+
+```
+Single template → StackSet → deploys to:
+                              - Account A in us-east-1
+                              - Account A in eu-west-1
+                              - Account B in us-east-1
+                              - … any combination of accounts × regions
+```
+
+Two permission models:
+
+| Model | When |
+| ----- | ---- |
+| **Self-managed permissions** | Each target account has a role you specify; admin account assumes it |
+| **Service-managed permissions** | Uses AWS Organizations to deploy automatically to all accounts in an OU; trusted access enabled |
+
+Heavily tested in multi-account / Control Tower / Organizations questions.
+
+#### Drift Detection
+
+CF can detect when a resource has been **modified outside of CloudFormation** (someone made a manual change in the console). Per-resource detection; not automatic — you trigger it. Output: list of drifted resources + which properties differ.
+
+Terraform's `terraform plan` does similar but operates on the whole state at once.
+
+#### DeletionPolicy and UpdateReplacePolicy
+
+Per-resource policies that control what happens on stack deletion or resource replacement:
+
+| Policy value | What it does |
+| ------------ | ------------ |
+| **Delete** (default) | Resource is destroyed with the stack |
+| **Retain** | Resource survives stack deletion (orphaned, you manage it manually) |
+| **Snapshot** | Snapshot is taken before deletion (EBS, RDS, ElastiCache, Redshift, Neptune) |
+
+`UpdateReplacePolicy` is the same but for in-place replacements during updates. Exam favourite for *"protect the DB during stack deletion"* → `DeletionPolicy: Retain` (or `Snapshot`).
+
+#### Helper scripts (EC2 bootstrap with signalling)
+
+Unique to CloudFormation, no Terraform equivalent:
+
+| Helper | Purpose |
+| ------ | ------- |
+| **`cfn-init`** | Runs in EC2 user data; reads `AWS::CloudFormation::Init` metadata from the template and configures the instance (packages, files, services) |
+| **`cfn-signal`** | Reports back to CF "I'm ready" or "I failed" — lets `WaitCondition` or `CreationPolicy` actually wait for instance readiness |
+| **`cfn-hup`** | Daemon that polls for template metadata changes and re-runs `cfn-init` |
+
+Exam triggers: *"wait until the EC2 instance is fully configured before marking the stack as complete"* → `cfn-signal` + `CreationPolicy: ResourceSignal`.
+
+#### SAM (Serverless Application Model) and CDK
+
+| | SAM | CDK |
+| - | --- | --- |
+| What | CF extension via `Transform: AWS::Serverless-2016-10-31`; shorthand for Lambda + API Gateway + DynamoDB patterns | TypeScript / Python / Java / Go SDK that **synthesises CloudFormation templates** |
+| Output | CloudFormation template | CloudFormation template |
+| Use for | Lightweight serverless apps | Anything where you want real programming-language abstractions over IaC |
+| Relationship | CF + sugar | CF + code generator |
+
+Both ultimately produce CF templates and deploy via CF stacks. They're not separate IaC systems.
+
+### CloudFormation vs Terraform — decision matrix
+
+| Scenario | Choose |
+| -------- | ------ |
+| **Multi-cloud or hybrid** | **Terraform** (CF is AWS-only) |
+| **AWS-only, want native state + rollback** | **CloudFormation** |
+| **Deploying to many AWS accounts via Organizations** | **CloudFormation StackSets** |
+| **Want rich expressions, modules, ecosystem** | **Terraform** |
+| **Want EC2 bootstrap to signal back when ready** | **CloudFormation** (`cfn-signal`) |
+| **AWS service explicitly speaks CF** (Service Catalog, Control Tower CfCT, AWS Backup, Migration Hub) | **CloudFormation** (the path of least resistance) |
+| **Writing infra in TypeScript / Python** | **CDK** (synthesises CF) or CDKTF (synthesises Terraform) |
+| **Existing Terraform shop with AWS workloads** | **Terraform** (don't fork the toolchain) |
+| **Lightweight serverless app deployment** | **SAM** (CF extension) |
+
+Most large orgs end up with **both**: Terraform for the bulk of infrastructure, CF for the AWS-specific bits that integrate natively (Service Catalog products, StackSets across accounts, Control Tower customisations).
+
+### Exam triggers
+
+| Question phrasing | Answer |
+| ----------------- | ------ |
+| *"AWS-native IaC"* | **CloudFormation** |
+| *"Deploy same template to 50 accounts and 3 regions"* | **CloudFormation StackSets** |
+| *"Service-managed permissions for StackSets across Organizations"* | **AWS Organizations + Trusted Access** for CloudFormation |
+| *"Preview changes before applying"* | **Change Set** (CF's `terraform plan`) |
+| *"Resource should survive stack deletion"* | **DeletionPolicy: Retain** (or `Snapshot` for DBs) |
+| *"Detect manual changes outside CF"* | **Drift Detection** |
+| *"Bootstrap EC2 and signal back when ready"* | **`cfn-init` + `cfn-signal` + `CreationPolicy: ResourceSignal`** |
+| *"Auto-rollback if stack fails"* | **Default behaviour** — CF rolls back on failure (don't disable unless you know why) |
+| *"Synthesise CF templates from TypeScript/Python"* | **AWS CDK** |
+| *"Shorthand for serverless app templates"* | **AWS SAM** (CF transform) |
+| *"Block non-compliant resource creation BEFORE deployment"* | **CloudFormation Hooks** (proactive controls) |
+| *"Reusable infrastructure pattern within one template"* | **Nested Stacks** |
+| *"Reference outputs between stacks"* | **Export + `!ImportValue`** (cross-stack references) |
+
+### Mental model
+
+> *CloudFormation = **"Terraform but AWS-only, with state managed by AWS, automatic rollback on failure, and native StackSets for multi-account deployment."** If you know Terraform, the concepts map 1:1 (template = .tf, stack = state + workspace, resources, parameters, outputs, conditions, intrinsic functions ≈ HCL expressions). **What CF wins on:** automatic rollback, StackSets, native AWS-service integrations, helper scripts for EC2 readiness signalling, DeletionPolicy: Retain/Snapshot. **What Terraform wins on:** multi-cloud, HCL expressiveness, module ecosystem, faster iteration. Most orgs use both. **SAM** and **CDK** both produce CF templates — they're not alternatives to CF, they're authoring layers on top of it.*
 
 ## Solution Architecture Examples
 

--- a/README.md
+++ b/README.md
@@ -11534,26 +11534,142 @@ aws cloudformation execute-change-set ...   # applies it
 
 Equivalent of `terraform plan → terraform apply`. Critical for production — always review before executing.
 
-#### StackSets — multi-account multi-region (the headline CF feature)
+#### StackSets — multi-account multi-region deployment (the headline CF feature)
 
-The thing CF does that Terraform really can't match natively:
+The thing CF does that Terraform really can't match natively: **deploy one template to many accounts × many regions in a single operation.** Without StackSets you'd run `aws cloudformation deploy` 150 times in a loop.
+
+##### The mental model
 
 ```
-Single template → StackSet → deploys to:
-                              - Account A in us-east-1
-                              - Account A in eu-west-1
-                              - Account B in us-east-1
-                              - … any combination of accounts × regions
+Single CF Template (e.g. "deploy CloudWatch agent IAM role")
+       │
+       ▼
+Single StackSet (the "blueprint" — lives in admin account)
+       │
+       │ creates "stack instances" — one per target
+       ▼
+   ┌────────────┬────────────┬────────────┐
+   ▼            ▼            ▼            ▼
+Account A    Account A    Account B    Account B
+us-east-1    eu-west-1    us-east-1    eu-west-1
+(stack)      (stack)      (stack)      (stack)
 ```
 
-Two permission models:
+Each (account × region) gets its own actual CloudFormation **stack** (called a "stack instance"). The **StackSet** is the parent blueprint that manages all of them.
 
-| Model | When |
-| ----- | ---- |
-| **Self-managed permissions** | Each target account has a role you specify; admin account assumes it |
-| **Service-managed permissions** | Uses AWS Organizations to deploy automatically to all accounts in an OU; trusted access enabled |
+##### Core terminology
 
-Heavily tested in multi-account / Control Tower / Organizations questions.
+| Concept | What it is |
+| ------- | ---------- |
+| **StackSet** | The blueprint — lives in the admin (or delegated) account |
+| **Stack instance** | An individual stack created in a target account/region |
+| **Stack operation** | A single "deploy / update / delete" action that fans out to all stack instances |
+| **Target accounts** | A list of specific account IDs, OR an **OU** (with service-managed permissions) |
+| **Target regions** | List of regions to deploy to |
+| **Permission model** | Self-managed (you set up IAM roles) or service-managed (Organizations handles it) |
+
+##### The two permission models (constant exam question)
+
+| | **Self-managed permissions** | **Service-managed permissions** |
+| - | ----------------------------- | -------------------------------- |
+| Setup | Create `AWSCloudFormationStackSetAdministrationRole` in admin + `AWSCloudFormationStackSetExecutionRole` in **each** target account that trusts the admin | Enable **trusted access** for CloudFormation in AWS Organizations — AWS creates the roles |
+| Target by | **Specific account IDs** | **AWS Organizations OUs** |
+| Auto-deploy to new accounts joining an OU | ❌ No — manual update | ✅ **Yes** — stacks auto-deploy when accounts join the OU |
+| Auto-remove on accounts leaving OU | ❌ | ✅ Configurable |
+| Cross-organisation deployment | ✅ Yes (any account combination) | ❌ Tied to your Organization |
+| Setup effort | High (per-account IAM roles) | Low (one trusted-access toggle) |
+| Modern default? | Legacy / when no Organizations | ✅ **Recommended** — what Control Tower uses |
+
+**Exam decision:** *"deploy to all accounts in Organizations with auto-deploy to new accounts"* → **service-managed**. *"deploy to a specific list of accounts not all in the same Organization"* → **self-managed**.
+
+##### Deployment safety knobs
+
+When fanning out to dozens of accounts, things go wrong in some. StackSets has built-in safety controls — set them explicitly:
+
+| Control | What it does |
+| ------- | ------------ |
+| **Max concurrent accounts** | "Deploy to no more than 5 accounts at a time." Limits blast radius |
+| **Failure tolerance** | "Stop the operation if more than N accounts fail." **Default is 0 — one failure halts the whole rollout.** Always set this explicitly |
+| **Region order** | Deploy region-by-region (e.g. dev first, then prod). Staged rollout |
+| **Retain stacks on delete** | Removing a stack instance from a StackSet keeps the underlying stack — useful for handoffs |
+
+##### How a deployment actually flows
+
+```
+1. Create StackSet in the admin / delegated account
+   → Template uploaded
+   → Permission model chosen (service-managed)
+   → Targets: "OU: Production" + regions ["us-east-1", "eu-west-1"]
+       ↓
+2. CF calculates the target set:
+   → 30 accounts in Production OU × 2 regions = 60 stack instances
+       ↓
+3. Set deployment options:
+   → Max concurrent: 5 accounts
+   → Failure tolerance: 3 accounts
+   → Region order: us-east-1 first, then eu-west-1
+       ↓
+4. CF deploys (us-east-1 first):
+   → 5 accounts in parallel → 30 accounts × ~5 min ≈ 30 min for us-east-1
+   → If <4 fail, proceed to eu-west-1
+   → If >3 fail, halt operation (manual intervention)
+       ↓
+5. Operation complete:
+   → 60 stack instances exist
+   → Each is a normal CF stack in its target account/region
+       ↓
+6. New account joins Production OU later:
+   → Service-managed + auto-deployment ON → StackSet auto-deploys
+   → Self-managed → manual addition required
+```
+
+##### Common use cases (heavily tested)
+
+| Use case | What you deploy via StackSets |
+| -------- | ----------------------------- |
+| **Baseline IAM roles in every account** | Cross-account admin roles, security audit roles |
+| **CloudWatch agent IAM permissions** | Same monitoring policy everywhere |
+| **CloudTrail / Config / GuardDuty enablement** | Security baseline (Control Tower uses StackSets for this) |
+| **VPC baselines** | Default VPC tags, Flow Logs, baseline NACL |
+| **Config Conformance Packs** | Standardised compliance rule sets |
+| **Service Catalog products** | Vended products replicated to all accounts |
+| **Backup plans** | Org-wide AWS Backup configurations |
+
+**Control Tower uses StackSets under the hood** to deploy its guardrails to every member account. Most "Control Tower deploys X everywhere" questions are implicitly StackSets questions.
+
+##### What StackSets is NOT
+
+| Confused with | Actually is |
+| ------------- | ----------- |
+| **Nested Stacks** | Stack-within-a-stack in **one** account. StackSets = same stack across **many** accounts/regions |
+| **Cross-Stack References** (Export / `!ImportValue`) | Share outputs between stacks within ONE account/region. StackSets fans out to many |
+| **AWS Service Catalog** | Service Catalog is a vended-products UI layer. StackSets is the deployment mechanism (Service Catalog uses CF under the hood) |
+| **AWS Organizations alone** | Organizations is the structure (accounts, OUs, SCPs). StackSets uses Organizations for targeting in service-managed mode but is the deployment engine |
+
+##### Common gotchas
+
+| Gotcha | Detail |
+| ------ | ------ |
+| **Failure tolerance defaults to 0** | One failure halts the whole rollout. Always set explicitly |
+| **Permission model can't be changed after creation** | Pick service-managed if you have Organizations — switching later means recreating |
+| **Updates can be slow at scale** | 100 accounts × 3 regions = 300 instances; rate-limited |
+| **Stack instances are independent stacks** | A target-account admin can modify them manually — drift detection catches this but only when you run it |
+| **The admin account itself is NOT a target by default** | Add it explicitly if needed |
+| **Auto-deployment must be enabled** | Service-managed StackSets don't auto-deploy to new OU members unless you enable it |
+
+##### Exam triggers
+
+| Question phrasing | Answer |
+| ----------------- | ------ |
+| *"Deploy same baseline IAM role to all 50 accounts in Organization"* | **StackSets + service-managed permissions** targeting the root OU |
+| *"Auto-deploy a stack to new accounts joining an OU"* | **Service-managed StackSets** with auto-deployment enabled |
+| *"Deploy to specific accounts NOT all in same Organization"* | **Self-managed permissions** (manual IAM roles per target) |
+| *"Limit blast radius during multi-account deployment"* | **Max concurrent + failure tolerance + region order** |
+| *"Halt deployment if too many accounts fail"* | **Failure tolerance** on the stack operation |
+| *"How does Control Tower deploy guardrails to all accounts?"* | **CloudFormation StackSets with service-managed permissions** |
+| *"Deploy across multiple regions in one go"* | **StackSets** (set target regions list) |
+| *"Detect manual changes across stack instances in 100 accounts"* | **StackSet drift detection** runs across all instances |
+| *"Why didn't my StackSet deploy to the new account that joined the OU?"* | **Auto-deployment must be enabled** in service-managed mode |
 
 #### Drift Detection
 

--- a/cheatsheet/README.md
+++ b/cheatsheet/README.md
@@ -518,6 +518,11 @@ aws elasticache describe-cache-clusters --max-items 5
 
 # list topics
 aws elasticache describe-cache-clusters --cache-cluster-id ${CLUSTER_ID}
+
+# list replication groups (cluster-mode / Multi-AZ Redis) as a table
+aws elasticache describe-replication-groups --region eu-west-1 \
+  --query 'ReplicationGroups[*].{id:ReplicationGroupId,status:Status,nodes:NumNodeGroups,desc:Description}' \
+  --output table 2>&1 | head -30
 ```
 
 ## Cloudwatch

--- a/cheatsheet/README.md
+++ b/cheatsheet/README.md
@@ -615,6 +615,11 @@ aws cloudwatch get-metric-statistics \
 ```bash
 aws rds describe-db-clusters | jq '.DBClusters[] | select(.EngineVersion | contains("9.6")) | { name: .DBClusterIdentifier, version: .EngineVersion }'
 
+# list DB clusters (Aurora / RDS multi-instance) as a table
+aws rds describe-db-clusters --region eu-west-1 \
+  --query 'DBClusters[*].{id:DBClusterIdentifier,engine:Engine,status:Status,endpoint:Endpoint}' \
+  --output table 2>&1 | head -30
+
 aws rds describe-db-engine-versions --engine postgres | grep -A 1 AutoUpgrade| grep -A 2 true |grep PostgreSQL | sort --unique | sed -e 's/"Description": "//g'
 
 aws rds download-db-log-file-portion \


### PR DESCRIPTION
## Summary

Second misc PR. Starts with a focused **AWS CloudFormation** section anchored against Terraform — the user knows Terraform well, so this is a delta-based explanation rather than a from-scratch IaC walkthrough.

### What's in this section

- **Concept mapping table** (CF construct → Terraform equivalent) covering Templates / Stacks / Resources / Parameters / Outputs / Conditions / Intrinsic Functions / Change Sets / DeletionPolicy / Nested Stacks / StackSets / Registry / Macros / SAM / CDK
- **What CF wins on** vs Terraform — automatic rollback, AWS-managed state, native drift detection, StackSets for multi-account/region, EC2 bootstrap signalling (cfn-init / cfn-signal), native integration with Service Catalog / Control Tower / AWS Backup
- **What Terraform wins on** vs CF — multi-cloud, HCL expressiveness, module ecosystem, faster iteration
- **Exam-relevant specifics** — stack lifecycle + automatic rollback, Change Sets, StackSets (self-managed vs service-managed permissions), Drift Detection, DeletionPolicy: Retain/Snapshot, cfn-init / cfn-signal helper scripts, SAM and CDK as authoring layers on top of CF
- **Decision matrix** for CF vs Terraform across 9 scenarios
- **13 exam triggers** + mental model

Section sits between Elastic Beanstalk and Solution Architecture Examples.

## Test plan

- [x] Markdown lint passes locally (0 errors)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)